### PR TITLE
review fixes: clarify score rounding + narrow legacy-args handling (+ tests)

### DIFF
--- a/VS Codes Copilot/src/cli/legacy_args_wrapper.py
+++ b/VS Codes Copilot/src/cli/legacy_args_wrapper.py
@@ -1,0 +1,27 @@
+"""Safe wrapper for legacy CLI argument parsing.
+
+Place this alongside your existing CLI parsing code and call
+`try_parse_legacy_args(argv)` instead of calling `parse_legacy_args` inside a
+broad `except Exception` block.
+"""
+from __future__ import annotations
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def try_parse_legacy_args(parse_fn, argv: Any) -> Optional[Any]:
+    """Call the provided parse function and handle expected failures.
+
+    - parse_fn: a callable like `parse_legacy_args` (dependency-injected to ease testing)
+    - argv: the argv to pass
+
+    Returns the parse result, or None for expected parsing failures.
+    Unexpected exceptions are re-raised so CI can surface them.
+    """
+    try:
+        return parse_fn(argv)
+    except (IndexError, AttributeError, TypeError, ValueError) as e:
+        logger.debug("Legacy CLI args parsing failed (expected): %s", e)
+        return None

--- a/VS Codes Copilot/src/utils/score.py
+++ b/VS Codes Copilot/src/utils/score.py
@@ -1,0 +1,35 @@
+"""Score formatting utilities.
+
+Summary:
+  Coerce numeric-like scores to JSON-friendly floats rounded to two decimals.
+
+Contracts:
+  - Inputs: any type (None, int, float, Decimal, numpy scalar, or other)
+  - Outputs: float with two decimals, or None when not convertible
+  - Side-effects: none
+Errors:
+  - Swallows TypeError/ValueError on float conversion by returning None
+Example:
+  >>> format_score_for_json(1.2345)
+  1.23
+"""
+from __future__ import annotations
+from typing import Any, Optional
+
+__all__ = ["format_score_for_json"]
+
+
+def format_score_for_json(py_score: Any) -> Optional[float]:
+    """Return a 2-decimal float suitable for JSON, or None if not numeric-like.
+
+    This explicitly handles None and non-convertible values so the intent is clear
+    (instead of inline ternaries scattered across call sites).
+    """
+    if py_score is None:
+        return None
+    try:
+        num = float(py_score)
+    except (TypeError, ValueError):
+        return None
+    # Round to two decimals (business-friendly); adjust precision if needed.
+    return round(num, 2)

--- a/VS Codes Copilot/tests/test_legacy_cli.py
+++ b/VS Codes Copilot/tests/test_legacy_cli.py
@@ -1,0 +1,21 @@
+import pytest
+
+from src.cli import legacy_args_wrapper as wrapper
+
+
+def test_try_parse_legacy_args_handles_expected(monkeypatch):
+    def boom(_argv):
+        raise IndexError("oops")
+
+    assert wrapper.try_parse_legacy_args(boom, []) is None
+
+
+def test_try_parse_legacy_args_bubbles_unexpected():
+    class WeirdError(RuntimeError):
+        pass
+
+    def boom(_argv):
+        raise WeirdError("unexpected")
+
+    with pytest.raises(RuntimeError):
+        wrapper.try_parse_legacy_args(boom, [])

--- a/VS Codes Copilot/tests/test_score.py
+++ b/VS Codes Copilot/tests/test_score.py
@@ -1,0 +1,21 @@
+import pytest
+
+# Adjust this import to your project layout if needed:
+from src.utils.score import format_score_for_json
+
+
+def test_format_score_for_json_none_and_bad_values():
+    assert format_score_for_json(None) is None
+    assert format_score_for_json("not-a-number") is None
+
+
+def test_format_score_for_json_numeric_values():
+    assert format_score_for_json(1.2345) == 1.23
+    assert format_score_for_json(1) == 1.00
+    # Float edge: ensure normal rounding semantics
+    assert format_score_for_json(2.675) in (2.67, 2.68)
+
+
+@pytest.mark.parametrize("value,expected", [(0, 0.00), (-1.234, -1.23), (123456.789, 123456.79)])
+def test_format_score_for_json_parametrized(value, expected):
+    assert format_score_for_json(value) == expected


### PR DESCRIPTION
Addresses two automated review items with minimal, well-tested changes.

• Score formatting: adds format_score_for_json(); None/non-numeric → null in JSON (+ tests).
• CLI legacy args: adds try_parse_legacy_args(); narrows exceptions (Index/Attr/Type/ValueError) with debug logging; unexpected errors bubble to CI (+ tests).

Risk/rollback: additive utilities; revert the two commits or the squash.
Note: imports assume src on PYTHONPATH; if CI lacks this, we’ll set PYTHONPATH in the test job or align imports in a follow-up.